### PR TITLE
Python 3.10 issue (Collections), CairoSVG Issue, DeleteFirstSlide directive

### DIFF
--- a/md2pptx
+++ b/md2pptx
@@ -12,6 +12,8 @@ import re
 import sys
 import os
 import time
+import collections 
+import collections.abc
 from pptx import Presentation
 from pptx import __version__ as pptx_version
 from pptx.util import Inches, Pt
@@ -256,6 +258,7 @@ def resolveSymbols(text):
     text2 = text2.replace("&nu;", "ν")
     text2 = text2.replace("&pi;", "π")
     text2 = text2.replace("&rho;", "ρ")
+    text2 = text2.replace("&dash;", "-")
 
     return text2
 
@@ -4238,7 +4241,9 @@ for line in metadata_lines:
 
     elif name == "sectionsubtitlesize":
         processingOptions.setOptionValues(name, float(value))
-
+    elif name == "deletefirstslide":
+        processingOptions.setDefaultOption("deletefirstslide", True)
+        
     elif (name == "template") | (name == "master"):
         if value == "Martin Master.pptx":
             slideTemplateFile = "Martin Template.pptx"
@@ -5490,7 +5495,13 @@ for p in range(picture_count):
 if templateSlideCount > 0:
     createProcessingSummarySlide(prs, metadata)
 
-# Write out the finished presentation
+if processingOptions.getDefaultOption("deletefirstslide"):
+    # Write out the finished presentation - Removing First Slide
+    slide_list_to_dlt = [0]
+    for sldNum in slide_list_to_dlt:
+        rId = prs.slides._sldIdLst[sldNum].rId
+        prs.part.drop_rel(rId)
+        del prs.slides._sldIdLst[sldNum]
 prs.save(output_filename)
 
 elapsed_time = time.time() - start_time

--- a/md2pptx
+++ b/md2pptx
@@ -35,7 +35,6 @@ import tempfile
 import copy
 import platform
 import shutil
-from cairosvg import helpers
 
 from lxml import etree
 from lxml.html import fromstring
@@ -44,6 +43,7 @@ from lxml.html import fromstring
 # Flag availability or otherwise
 try:
     import cairosvg
+    from cairosvg import helpers
 
     have_cairosvg = True
 except:
@@ -5495,13 +5495,17 @@ for p in range(picture_count):
 if templateSlideCount > 0:
     createProcessingSummarySlide(prs, metadata)
 
-if processingOptions.getDefaultOption("deletefirstslide"):
-    # Write out the finished presentation - Removing First Slide
-    slide_list_to_dlt = [0]
-    for sldNum in slide_list_to_dlt:
-        rId = prs.slides._sldIdLst[sldNum].rId
-        prs.part.drop_rel(rId)
-        del prs.slides._sldIdLst[sldNum]
+try:
+    if processingOptions.getDefaultOption("deletefirstslide"):
+        # Write out the finished presentation - Removing First Slide
+        slide_list_to_dlt = [0]
+        for sldNum in slide_list_to_dlt:
+            rId = prs.slides._sldIdLst[sldNum].rId
+            prs.part.drop_rel(rId)
+            del prs.slides._sldIdLst[sldNum]
+except:
+    pass
+
 prs.save(output_filename)
 
 elapsed_time = time.time() - start_time


### PR DESCRIPTION
Martin,

In python 3.10, we have to import the collections prior to importing Presentation.

This address that.

Also, there's a bug introduced in this version.  I moved the import cairo helpers into the try block.  Mine was failing.

I also added a new "deletefirstslide" global directive.  If the directive is set, it will delete the first slide.  It's in a try block, as the helper fails if it is not set.  If it fails, the except block just passes the normal save operation.