### PR TITLE
Fix link in user guide for template customization

### DIFF
--- a/docs/user-guide.html
+++ b/docs/user-guide.html
@@ -3392,7 +3392,7 @@ For everything else use <code>marginBase</code>.</p>
 <p>You can specify a different template file to create the presentation from than the one supplied with python-pptx. The one supplied with md2pptx is a very good one to work from:</p>
 <pre><code>template: Martin Template.pptx
 </code></pre>
-<p>If you want to create your own template you probably want to take Martin Template.pptx and modify it. See <a href="/Users/martinpacker/md2pptx/docs/modifying-the-slide-template">Modifying The Slide Template</a> for more information on how to do so.</p>
+<p>If you want to create your own template you probably want to take Martin Template.pptx and modify it. See <a href="#modifying-the-slide-template">Modifying The Slide Template</a> for more information on how to do so.</p>
 <p>(For compatibility purposes, you can continue to use <code>master</code> instead of <code>template</code>. It&rsquo;s probably better practice, though, to use <code>template</code>.)</p>
 <p>Templates are searched for in the following sequence:</p>
 <ol>

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2006,7 +2006,7 @@ You can specify a different template file to create the presentation from than t
 
 	template: Martin Template.pptx
 
-If you want to create your own template you probably want to take Martin Template.pptx and modify it. See [Modifying The Slide Template](modifying-the-slide-template) for more information on how to do so.
+If you want to create your own template you probably want to take Martin Template.pptx and modify it. See [Modifying The Slide Template](#modifying-the-slide-template) for more information on how to do so.
 
 (For compatibility purposes, you can continue to use `master` instead of `template`. It's probably better practice, though, to use `template`.)
 


### PR DESCRIPTION
Previous link had an absolute url in the html file, and a missing anchor tag # in the .md file