### PR TITLE
Fix multiple footnotes and hyperlinks support

### DIFF
--- a/md2pptx
+++ b/md2pptx
@@ -6378,10 +6378,17 @@ if len(globals.footnoteDefinitions) > 0:
     footnoteNumber = -1
     for footnoteRun in globals.footnoteRunsDictionary.keys():
         footnoteNumber += 1
-        run = globals.footnoteRunsDictionary[footnoteRun]
-
+        runs = globals.footnoteRunsDictionary[footnoteRun]
+        
+        # Handle both single run (old format) and multiple runs (new format)
+        if isinstance(runs, list):
+            run_list = runs
+        else:
+            run_list = [runs]
+        
         footnoteSlideNumber = int(footnoteNumber / footnotesPerPage)
-        createRunHyperlinkOrTooltip(run, footnoteSlides[footnoteSlideNumber], "")
+        for run in run_list:
+            createRunHyperlinkOrTooltip(run, footnoteSlides[footnoteSlideNumber], "")
 
 ######################################################################################
 #                                                                                    #
@@ -6532,11 +6539,19 @@ if globals.processingOptions.getCurrentOption("sectionArrows"):
 ######################################################################################
 xrefCheck_errors = False
 for href in globals.href_runs.keys():
-    run = globals.href_runs[href]
+    runs = globals.href_runs[href]
+    
+    # Handle both single run (old format) and multiple runs (new format)
+    if isinstance(runs, list):
+        run_list = runs
+    else:
+        run_list = [runs]
+    
     if href in slideHrefs.keys():
-        createRunHyperlinkOrTooltip(
-            run, prs.slides[slideHrefs[href] - 2 + templateSlideCount], ""
-        )
+        for run in run_list:
+            createRunHyperlinkOrTooltip(
+                run, prs.slides[slideHrefs[href] - 2 + templateSlideCount], ""
+            )
     else:
         # No id defined with that name
         if not xrefCheck_errors:
@@ -6545,11 +6560,12 @@ for href in globals.href_runs.keys():
             print("\nHyperlink Reference Errors")
             print("--------------------------")
 
-        print(
-            "Slide "
-            + str(prs.slides.index(SlideFromRun(run)) + 1 - templateSlideCount)
-            + f": '{href}'"
-        )
+        for run in run_list:
+            print(
+                "Slide "
+                + str(prs.slides.index(SlideFromRun(run)) + 1 - templateSlideCount)
+                + f": '{href}'"
+            )
 
 # Each picture appears in pictures
 # There's a corresponding entry in picture_Hrefs

--- a/paragraph.py
+++ b/paragraph.py
@@ -626,7 +626,10 @@ def addFormattedText(p, text):
                 if fnref in globals.footnoteReferences:
                     footnoteNumber = globals.footnoteReferences.index(fnref)
                     run.text = str(footnoteNumber + 1)
-                    globals.footnoteRunsDictionary[footnoteNumber] = run
+                    # Support multiple runs per footnote reference
+                    if footnoteNumber not in globals.footnoteRunsDictionary:
+                        globals.footnoteRunsDictionary[footnoteNumber] = []
+                    globals.footnoteRunsDictionary[footnoteNumber].append(run)
 
                 else:
                     run.text = "[?]"
@@ -693,7 +696,10 @@ def addFormattedText(p, text):
                 if linkURL.startswith("#"):
                     # Is an internal Url
                     linkHref = linkURL[1:].strip()
-                    globals.href_runs[linkHref] = run
+                    # Support multiple runs per href target
+                    if linkHref not in globals.href_runs:
+                        globals.href_runs[linkHref] = []
+                    globals.href_runs[linkHref].append(run)
                 else:
                     # Not an internal link so create it
                     hlink = run.hyperlink


### PR DESCRIPTION
## Summary
Fix support for multiple references to the same footnote or hyperlink target.

## Changes
- Support multiple runs per footnote reference in `paragraph.py`
- Support multiple runs per hyperlink target (#href) in `paragraph.py`  
- Handle both old format (single run) and new format (list of runs) in `md2pptx`
- Fixes issues when same footnote/hyperlink is referenced multiple times on different slides

## Files Modified
- `paragraph.py`: Updated footnote and hyperlink run storage to use lists
- `md2pptx`: Updated footnote and hyperlink processing to handle multiple runs

## Testing
- Footnotes can now be referenced multiple times across slides
- From what I’ve tested so far, everything seems to be working correctly