### PR TITLE
Fix file extension on image download

### DIFF
--- a/md2pptx
+++ b/md2pptx
@@ -1369,14 +1369,14 @@ def handleWhateverGraphicType(GraphicFilename):
                 # Note: It's been translated to lower case above
                 if content_type in ["image/jpeg", "image/jpg"]:
                     # Note: only the first of these two is legitimate
-                    fileExt = "jpg"
+                    fileExt = ".jpg"
                 elif content_type == "image/png":
-                    fileExt = "png"
+                    fileExt = ".png"
                 elif content_type in ["image/svg+xml", "image/svg"]:
                     # Note: only the first of these two is legitimate
-                    fileExt = "svg"
+                    fileExt = ".svg"
                 elif content_type == "application/postscript":
-                    fileExt = "eps"
+                    fileExt = ".eps"
                 else:
                     fileExt = None
         else:


### PR DESCRIPTION
Currently when downloading a referenced image, if its file extension is inferred from URL suffix, there will be a dot in the front of suffix; there won't be if matching Content-Type.

Add a dot in the front of `suffix` on HTTP Response with a Content-Type header to make filename with extension in order to insert the image into pptx file correctly.