### PR TITLE
feat: fall back to python-pptx built-in template when configured template is missing

### DIFF
--- a/md2pptx
+++ b/md2pptx
@@ -5687,12 +5687,17 @@ if slideTemplateFile != "":
         # Slide template file is not present if we expand path
         slideTemplateFile = md2pptx_path + os.sep + slideTemplateFile
         if not Path(slideTemplateFile).exists():
+            # Template not found. Fall back to the python-pptx built-in
+            # default so the user still gets something to review, and warn
+            # so they know the configured template was missing.
             print(
-                f"\nTemplate file {originalSlideTemplateFile} does not exist. Terminating."
+                f"\nTemplate file {originalSlideTemplateFile} does not exist. "
+                f"Falling back to the python-pptx built-in template."
             )
-            sys.exit()
+            slideTemplateFile = ""
 
-    print(f"\nUsing {slideTemplateFile} as base for presentation")
+    if slideTemplateFile != "":
+        print(f"\nUsing {slideTemplateFile} as base for presentation")
 
 if slideTemplateFile == "":
     # Use default slide deck that comes with python-pptx as base


### PR DESCRIPTION
Closes #211

When the `template:` directive points at a file that does not exist, md2pptx currently prints `Template file X does not exist. Terminating.` and exits, forcing the user to either fix the path or remove the template setting before they see any output. This PR makes that path graceful: warn that the configured template is missing, clear `slideTemplateFile`, and reuse the existing no-template branch (which already constructs `prs = Presentation()` from python-pptx's built-in default).

## Change

`md2pptx` (the Python script — `md2pptx.py` is the convenience symlink), inside the `if not Path(slideTemplateFile).exists()` branch:

```python
print(
    f"\nTemplate file {originalSlideTemplateFile} does not exist. "
    f"Falling back to the python-pptx built-in template."
)
slideTemplateFile = ""
```

instead of the previous `sys.exit()`. The existing `if slideTemplateFile == "":` branch downstream already handles the no-template case (`prs = Presentation()` + `templateSlideCount = 0` + the existing "No slide to document metadata on" message), so the fix is purely "set the flag and fall through."

The `Using {slideTemplateFile} as base for presentation` print is also gated behind a non-empty `slideTemplateFile` so it doesn't fire with an empty path after the fallback.

## Behavior

| Configured `template:` | Before | After |
|---|---|---|
| `""` (empty) | Use built-in default | (unchanged) |
| Valid path | Use that template | (unchanged) |
| Path that doesn't exist | "Terminating." + `sys.exit()` | Warning + use built-in default |

## Verification

- `python -m py_compile md2pptx` — clean.
- Traced both branches: empty-template branch is hit on the new fallback, so the fall-through works without further code changes.