### PR TITLE
Fix footnote marker in slide title parsed as heading href

### DIFF
--- a/md2pptx
+++ b/md2pptx
@@ -1125,9 +1125,15 @@ def parseTitleText(titleLineString):
     slideTitleWithPossibleHref = titleLineString.strip().rstrip("#").rstrip()
 
     if hrefMatch := slideHrefRegex.match(slideTitleWithPossibleHref):
-        # Use the explicit href
-        slideTitle = hrefMatch.group(1)
-        href = hrefMatch.group(2)
+        candidate_href = hrefMatch.group(2)
+        if candidate_href.startswith("^"):
+            # Footnote marker — do not strip from the title
+            href = ""
+            slideTitle = slideTitleWithPossibleHref
+        else:
+            # Use the explicit heading href
+            slideTitle = hrefMatch.group(1)
+            href = candidate_href
     else:
         # No href
         href = ""


### PR DESCRIPTION
## Bug

`slideHrefRegex` matches any trailing `[...]` in a slide title,
including footnote references such as `[^1]`. When a footnote
marker appeared at the end of a title like:

    ## My slide title [^1]

the marker was stripped from the title and treated as a heading
href, so the footnote machinery never received it.

## Fix

Check whether the matched candidate href starts with `^` before
treating it as a heading href. If it does, leave the title
untouched so the footnote reference is preserved.

## Reproduction

1. Create a slide with a footnote reference in the title:
   `## My title [^1]`
2. Define the footnote: `[^1]: footnote text`
3. Before this fix, the footnote marker is lost from the title.
