### PR TITLE
Fix IndexError when slide has multiple media table blocks

### DIFF
--- a/md2pptx
+++ b/md2pptx
@@ -6590,6 +6590,9 @@ for lineNumber, line in enumerate(linesAfterConcatenation):
                 inList = False
                 inCard = False
 
+                # Create a new empty table entry for this block
+                tableRows.append([])
+
             # Start the creation of a new row
             tableRow = []
 
@@ -6632,9 +6635,7 @@ for lineNumber, line in enumerate(linesAfterConcatenation):
             for mediaItem in sorted(mediaItems):
                 tableRow.append(mediaItem[2])
 
-            # Add table row to saved table rows
-            if len(tableRows) == 0:
-                tableRows.append([])
+            # Add table row to the current table block
             tableRows[-1].append(tableRow)
 
             inTitle = False


### PR DESCRIPTION
## Bug

When a slide contains a media table block (images/video/audio)
after a list or other non-table block, md2pptx raises an IndexError:

    IndexError: list index out of range

in `createTableBlock`.

## Root cause

The parser appends `"table"` to `sequence` each time a new media
table block starts (when `inTable` transitions from `False` to
`True`), but only calls `tableRows.append([])` when `tableRows` is
completely empty. On the second media table block on a slide,
`tableRows` already has one entry, so the guard fires and the new
rows are appended to the previous table's entry. `sequence` ends
up with more `"table"` entries than `tableRows` has, causing the
index error.

Note: pipe-table blocks (`|` syntax) correctly call
`tableRows.append([])` on each new block — this fix makes media
table blocks consistent with that behaviour.

## Fix

Move `tableRows.append([])` into the `if inTable is False` block
so every new media table block always creates its own entry.
