### PR TITLE
Abstract slide now respects baseTextSize option

### DIFF
--- a/md2pptx
+++ b/md2pptx
@@ -1862,7 +1862,8 @@ def createAbstractSlide(presentation, slideNumber, titleText, paragraphs):
     p = abstractBox.text_frame.paragraphs[0]
     tf = abstractBox.text_frame
     f = p.font
-    f.size = Pt(22)
+    baseTextSize = globals.processingOptions.getCurrentOption("baseTextSize")
+    f.size = Pt(baseTextSize) if baseTextSize > 0 else Pt(22)
     for para, abstractParagraph in enumerate(paragraphs):
         paragraphLevel, paragraphText, paragraphType = abstractParagraph
 
@@ -1870,12 +1871,12 @@ def createAbstractSlide(presentation, slideNumber, titleText, paragraphs):
             # Spacer paragraph
             p = tf.add_paragraph()
             f = p.font
-            f.size = Pt(22)
+            f.size = Pt(baseTextSize) if baseTextSize > 0 else Pt(22)
 
             # Content paragraph
             p = tf.add_paragraph()
             f = p.font
-            f.size = Pt(22)
+            f.size = Pt(baseTextSize) if baseTextSize > 0 else Pt(22)
         addFormattedText(p, paragraphText)
 
     tf.word_wrap = True


### PR DESCRIPTION
## Problem

`createAbstractSlide` hardcodes `Pt(22)` for all paragraph fonts.
Every other slide type (list, code, table) already honours the
`baseTextSize` processing option, so abstract slides are
inconsistent — setting `baseTextSize` has no effect on them.

## Fix

Read `baseTextSize` from processing options and apply it when set
(> 0), falling back to `Pt(22)` to preserve existing behaviour
for users who do not set the option.
