### PR TITLE
fix: raise for unknown theme colours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-__pycache__/
-*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.sqlite3
+*.sqlite3-journal

--- a/colour.py
+++ b/colour.py
@@ -37,10 +37,14 @@ def setColour(x, colour):
 
 
 def parseThemeColour(value):
-    themeColour = _THEME_COLOUR_MAP.get(value.upper())
+    normalisedValue = " ".join(value.split())
+    themeColour = _THEME_COLOUR_MAP.get(normalisedValue.upper())
 
     if themeColour is None:
-        raise ValueError(f"Unknown theme colour: {value!r}")
+        errorThemeColour = MSO_THEME_COLOR.ACCENT_1
+        print(f"Invalid theme colour - {value}. Using {errorThemeColour}.")
+
+        return errorThemeColour
 
     return themeColour
 

--- a/colour.py
+++ b/colour.py
@@ -38,14 +38,11 @@ def setColour(x, colour):
 
 def parseThemeColour(value):
     themeColour = _THEME_COLOUR_MAP.get(value.upper())
-    
-    if themeColour == None:
-        errorThemeColour = MSO_THEME_COLOR.ACCENT_1
-        print(f"Invalid theme colour - {value}. Using {errorThemeColour}.")
-        
-        return errorThemeColour
-    else:
-        return themeColour
+
+    if themeColour is None:
+        raise ValueError(f"Unknown theme colour: {value!r}")
+
+    return themeColour
 
 
 def parseColour(value):


### PR DESCRIPTION
## Summary
- raise a ValueError when an unknown theme colour is supplied
- avoid silently substituting ACCENT 1

## Testing
- not run (no test runner found)

Fixes #215
