### PR TITLE
Add footnotesFontSize option for footnote slide text size

### DIFF
--- a/md2pptx
+++ b/md2pptx
@@ -4550,6 +4550,7 @@ def createFootnoteSlides(prs, slideNumber, footnoteDefinitions):
 
     footnotesTitle = globals.processingOptions.getCurrentOption("footnotesTitle")
     footnotesPerPage = globals.processingOptions.getCurrentOption("footnotesPerPage")
+    footnotesFontSize = globals.processingOptions.getCurrentOption("footnotesFontSize")
 
     footnoteCount = len(footnoteDefinitions)
 
@@ -4584,7 +4585,13 @@ def createFootnoteSlides(prs, slideNumber, footnoteDefinitions):
                 footnoteSlides.append(slide)
 
                 # Turn off bulleting
-                removeBullets(findBodyShape(slide).text_frame)
+                bodyFrame = findBodyShape(slide).text_frame
+                removeBullets(bodyFrame)
+
+                if footnotesFontSize > 0:
+                    for paragraph in bodyFrame.paragraphs:
+                        for run in paragraph.runs:
+                            run.font.size = Pt(footnotesFontSize)
 
                 slideNumber += 1
             bullets = []
@@ -4628,7 +4635,13 @@ def createFootnoteSlides(prs, slideNumber, footnoteDefinitions):
     footnoteSlides.append(slide)
 
     # Turn off bulleting
-    removeBullets(findBodyShape(slide).text_frame)
+    bodyFrame = findBodyShape(slide).text_frame
+    removeBullets(bodyFrame)
+
+    if footnotesFontSize > 0:
+        for paragraph in bodyFrame.paragraphs:
+            for run in paragraph.runs:
+                run.font.size = Pt(footnotesFontSize)
 
     slideNumber += 1
 
@@ -4988,7 +5001,7 @@ globals.processingOptions.setOptionValuesArray(
 
 # Footnotes defaults
 globals.processingOptions.setOptionValuesArray(
-    [["footnotesTitle", "Footnotes"], ["footnotesPerPage", 20]]
+    [["footnotesTitle", "Footnotes"], ["footnotesPerPage", 20], ["footnotesFontSize", 0]]
 )
 
 # Table Of Contents defaults
@@ -5487,6 +5500,9 @@ for line in metadata_lines:
 
     elif name == "footnotesperpage":
         globals.processingOptions.setOptionValues(name, int(value))
+
+    elif name == "footnotesfontsize":
+        globals.processingOptions.setOptionValues(name, float(value))
 
     elif name == "footnotestitle":
         globals.processingOptions.setOptionValues(name, value)


### PR DESCRIPTION
Closes #221

## Changes

- Add `footnotesFontSize` processing option (default `0` = no override)
- Apply the font size to all runs on each footnote slide after bullet removal
- Parse `footnotesfontsize` metadata key as `float`, consistent with `baseTextSize` and `tocFontSize`

## Usage

    footnotesFontSize: 14
