### PR TITLE
Normalize metadata aliases and TOC section linking

### DIFF
--- a/md2pptx
+++ b/md2pptx
@@ -3847,6 +3847,17 @@ def delinkify(text):
         return (text, "")
 
 
+def flattenBullets(bullets: list) -> list:
+    flattenedBullets = []
+    for bulletList in bullets:
+        if len(bulletList) == 3 and isinstance(bulletList[0], int):
+            flattenedBullets.append(bulletList)
+        else:
+            flattenedBullets.extend(bulletList)
+
+    return flattenedBullets
+
+
 def createTOCSlide(presentation, slideNumber, titleText, bullets, tocStyle):
     global SectionSlides
     titleOnlyLayout = globals.processingOptions.getCurrentOption("titleOnlyLayout")
@@ -3855,6 +3866,7 @@ def createTOCSlide(presentation, slideNumber, titleText, bullets, tocStyle):
     marginBase = globals.processingOptions.getCurrentOption("marginBase")
     pageTitleSize = globals.processingOptions.getCurrentOption("pageTitleSize")
     pageSubtitleSize = globals.processingOptions.getCurrentOption("pageSubtitleSize")
+    tocBullets = flattenBullets(bullets)
 
     if tocStyle != "plain":
         if titleText == tocTitle:
@@ -3879,7 +3891,7 @@ def createTOCSlide(presentation, slideNumber, titleText, bullets, tocStyle):
             )
         else:
             # Remove the links from the bullets and replace with target slide title
-            for bullet in bullets:
+            for bullet in tocBullets:
                 linkMatch = linkRegex.match(bullet[1])
                 bullet[1] = linkMatch.group(1)
 
@@ -3929,7 +3941,7 @@ def createTOCSlide(presentation, slideNumber, titleText, bullets, tocStyle):
     )
 
     # Create global list of TOC entries
-    for bullet in bullets:
+    for bullet in tocBullets:
         bulletLevel, bulletText, bulletType = bullet
         if bulletLevel == 0:
             # Level 0 is top level so create a TOC entry

--- a/md2pptx
+++ b/md2pptx
@@ -401,11 +401,6 @@ def startswithOneOf(haystack, needleList):
     return False
 
 
-# Splits a string into words, converting each word to an integer. Returns them as a
-# sorted list
-def sortedNumericList(string):
-    return sorted(list(map(int, set(string.split()))))
-
 
 def substituteFooterVariables(footerText, liveFooters):
     # Decide if the footer should be a live link to the section slide

--- a/md2pptx
+++ b/md2pptx
@@ -570,7 +570,7 @@ def applyTableLineStyling(
                     columnStyling = ""
                 cellStyling[rowNumber][columnNumber] = rowStyling + columnStyling
 
-    elif wholeTableLineStyling == "all":
+    elif wholeTableLineStyling in ["all", "both"]:
         # All edges of all cells have lines
         for rowNumber, row in enumerate(table.rows):
             lastColumn = len(row.cells) - 1

--- a/md2pptx
+++ b/md2pptx
@@ -5659,8 +5659,10 @@ for line in metadata_lines:
         globals.processingOptions.setOptionValues("funnelLabelsPercent", float(value))
 
     elif name in ["funnellabelposition", "funnellabelsposition"]:
-        if value in ["before", "after"]:
-            globals.processingOptions.setOptionValues("funnelLabelPosition", value)
+        if value.lower() in ["before", "after"]:
+            globals.processingOptions.setOptionValues(
+                "funnelLabelPosition", value.lower()
+            )
         else:
             print(
                 f'funnelLabelPosition value \'{value}\' unsupported. "before" or "after" required.'
@@ -6413,7 +6415,7 @@ for lineNumber, line in enumerate(linesAfterConcatenation):
                     ]:
                         globals.processingOptions.dynamicallySetOption(
                             "funnelLabelPosition",
-                            metadataValue,
+                            metadataValue.lower(),
                             "",
                         )
                     else:

--- a/md2pptx
+++ b/md2pptx
@@ -3858,6 +3858,19 @@ def flattenBullets(bullets: list) -> list:
     return flattenedBullets
 
 
+def funnelColourOptionName(name: str) -> str:
+    funnelColourOptions = {
+        "funneltitlecolour": "funnelTitleColour",
+        "funneltitlecolor": "funnelTitleColour",
+        "funnelbordercolour": "funnelBorderColour",
+        "funnelbordercolor": "funnelBorderColour",
+        "funneltextcolour": "funnelTextColour",
+        "funneltextcolor": "funnelTextColour",
+    }
+
+    return funnelColourOptions[name]
+
+
 def createTOCSlide(presentation, slideNumber, titleText, bullets, tocStyle):
     global SectionSlides
     titleOnlyLayout = globals.processingOptions.getCurrentOption("titleOnlyLayout")
@@ -5638,9 +5651,9 @@ for line in metadata_lines:
     elif name == "funnellabelspercent":
         globals.processingOptions.setOptionValues(name, float(value))
 
-    elif name == "funnellabelposition":
+    elif name in ["funnellabelposition", "funnellabelsposition"]:
         if value in ["before", "after"]:
-            globals.processingOptions.setOptionValues(name, value)
+            globals.processingOptions.setOptionValues("funnelLabelPosition", value)
         else:
             print(
                 f'funnelLabelPosition value \'{value}\' unsupported. "before" or "after" required.'
@@ -6220,13 +6233,22 @@ for lineNumber, line in enumerate(linesAfterConcatenation):
 
                 elif metadataKey in [
                     "funneltitlecolour",
+                    "funneltitlecolor",
                     "funnelbordercolour",
+                    "funnelbordercolor",
                     "funneltextcolour",
+                    "funneltextcolor",
                 ]:
                     # Funnel single colour options
-                    globals.processingOptions.dynamicallySetOption(
-                        metadataKey, metadataValue, ""
-                    )
+                    funnelColourOption = funnelColourOptionName(metadataKey)
+                    if metadataValue in ["default", "pres", "pop", "prev"]:
+                        globals.processingOptions.dynamicallySetOption(
+                            funnelColourOption, metadataValue, ""
+                        )
+                    else:
+                        globals.processingOptions.dynamicallySetOption(
+                            funnelColourOption, parseColour(metadataValue.strip()), ""
+                        )
 
                 elif metadataKey == "backgroundimage":
                     # Slide background image
@@ -6372,13 +6394,13 @@ for lineNumber, line in enumerate(linesAfterConcatenation):
                             f"Invalid value for {metadataKey}: {metadataValue} in '{line}"
                         )
 
-                elif metadataKey == "funnellabelposition":
+                elif metadataKey in ["funnellabelposition", "funnellabelsposition"]:
                     if metadataValue.lower() in [
                         "before",
                         "after",
                     ]:
                         globals.processingOptions.dynamicallySetOption(
-                            metadataKey,
+                            "funnelLabelPosition",
                             metadataValue,
                             "",
                         )

--- a/md2pptx
+++ b/md2pptx
@@ -5415,7 +5415,7 @@ for line in metadata_lines:
                 f'CardTitlePosition value \'{value}\' unsupported. "inside", "above", "before", or "after" required.'
             )
 
-    elif name == "cardGraphicPosition":
+    elif name == "cardgraphicposition":
         if value in ["before", "after"]:
             globals.processingOptions.setOptionValues(name, value)
         else:
@@ -6059,6 +6059,8 @@ for lineNumber, line in enumerate(linesAfterConcatenation):
                     "cardpercent",
                     # Card graphic's vertical or horizontal space
                     "cardgraphicsize",
+                    # Card graphic padding
+                    "cardgraphicpadding",
                     # Base text size
                     "basetextsize",
                     # Base text decrement
@@ -6164,7 +6166,7 @@ for lineNumber, line in enumerate(linesAfterConcatenation):
                         metadataKey, metadataValue, ""
                     )
 
-                elif metadataKey == "cardGraphicPosition":
+                elif metadataKey == "cardgraphicposition":
                     # Card graphic position - before or after
                     globals.processingOptions.dynamicallySetOption(
                         metadataKey, metadataValue, ""

--- a/md2pptx
+++ b/md2pptx
@@ -3871,6 +3871,10 @@ def funnelColourOptionName(name: str) -> str:
     return funnelColourOptions[name]
 
 
+def sectionSlideKey(titleText: str) -> str:
+    return titleText.strip()
+
+
 def createTOCSlide(presentation, slideNumber, titleText, bullets, tocStyle):
     global SectionSlides
     titleOnlyLayout = globals.processingOptions.getCurrentOption("titleOnlyLayout")
@@ -3922,7 +3926,7 @@ def createTOCSlide(presentation, slideNumber, titleText, bullets, tocStyle):
                 TOCruns.append(p.runs[0])
 
         # Store the new slide in the list of section slides - for fixing up links
-        SectionSlides[titleText] = slide
+        SectionSlides[sectionSlideKey(titleText)] = slide
 
         return slide
 
@@ -3932,7 +3936,7 @@ def createTOCSlide(presentation, slideNumber, titleText, bullets, tocStyle):
         )
         title = findTitleShape(slide)
 
-    SectionSlides[titleText] = slide
+    SectionSlides[sectionSlideKey(titleText)] = slide
 
     shapes = slide.shapes
 
@@ -6876,7 +6880,7 @@ if (len(tasks) > 0) & (taskSlides != "none"):
 if globals.processingOptions.getCurrentOption("tocLinks"):
     # Linkify section items
     for run in TOCruns:
-        createRunHyperlinkOrTooltip(run, SectionSlides[run.text])
+        createRunHyperlinkOrTooltip(run, SectionSlides[sectionSlideKey(run.text)])
 
 if globals.processingOptions.getCurrentOption("sectionArrows"):
     # Add navigation arrows between section slides

--- a/md2pptx
+++ b/md2pptx
@@ -2022,9 +2022,9 @@ def createListBlock(slideInfo, slide, renderingRectangle, listBlockNumber):
     cardTitleBackgrounds = globals.processingOptions.getCurrentOption("cardtitlebackground")
     cardColours = globals.processingOptions.getCurrentOption("cardcolour")
     cardDividerColour = globals.processingOptions.getCurrentOption("carddividercolour")
-    cardGraphicSize = globals.processingOptions.getCurrentOption("cardgraphicsize")
+    cardGraphicSize = globals.processingOptions.getCurrentOption("cardGraphicSize")
     cardGraphicPosition = globals.processingOptions.getCurrentOption("cardGraphicPosition")
-    cardGraphicPadding = int(Inches(globals.processingOptions.getCurrentOption("cardgraphicpadding")))
+    cardGraphicPadding = int(Inches(globals.processingOptions.getCurrentOption("cardGraphicPadding")))
     marginBase = globals.processingOptions.getCurrentOption("marginBase")
     pageTitleSize = globals.processingOptions.getCurrentOption("pageTitleSize")
     pageSubtitleSize = globals.processingOptions.getCurrentOption("pageSubtitleSize")
@@ -3858,17 +3858,14 @@ def flattenBullets(bullets: list) -> list:
     return flattenedBullets
 
 
-def funnelColourOptionName(name: str) -> str:
-    funnelColourOptions = {
-        "funneltitlecolour": "funnelTitleColour",
-        "funneltitlecolor": "funnelTitleColour",
-        "funnelbordercolour": "funnelBorderColour",
-        "funnelbordercolor": "funnelBorderColour",
-        "funneltextcolour": "funnelTextColour",
-        "funneltextcolor": "funnelTextColour",
-    }
 
-    return funnelColourOptions[name]
+def dynamicallySetColourOption(optionName: str, optionValue: str) -> None:
+    if optionValue in ["default", "pres", "pop", "prev"]:
+        globals.processingOptions.dynamicallySetOption(optionName, optionValue, "")
+    else:
+        globals.processingOptions.dynamicallySetOption(
+            optionName, parseColour(optionValue.strip()), ""
+        )
 
 
 def sectionSlideKey(titleText: str) -> str:
@@ -5405,8 +5402,14 @@ for line in metadata_lines:
         if value.lower() == "yes":
             globals.processingOptions.setOptionValues(name, True)
 
-    elif name in ["cardpercent", "cardgraphicsize", "cardgraphicpadding"]:
+    elif name == "cardpercent":
         globals.processingOptions.setOptionValues(name, float(value))
+
+    elif name == "cardgraphicsize":
+        globals.processingOptions.setOptionValues("cardGraphicSize", float(value))
+
+    elif name == "cardgraphicpadding":
+        globals.processingOptions.setOptionValues("cardGraphicPadding", float(value))
 
     elif name == "cardlayout":
         if value in ["horizontal", "vertical"]:
@@ -5434,7 +5437,7 @@ for line in metadata_lines:
 
     elif name == "cardgraphicposition":
         if value in ["before", "after"]:
-            globals.processingOptions.setOptionValues(name, value)
+            globals.processingOptions.setOptionValues("cardGraphicPosition", value)
         else:
             print(
                 f'cardGraphicPosition value \'{value}\' unsupported. "before",or "after" required.'
@@ -5653,7 +5656,7 @@ for line in metadata_lines:
         )
 
     elif name == "funnellabelspercent":
-        globals.processingOptions.setOptionValues(name, float(value))
+        globals.processingOptions.setOptionValues("funnelLabelsPercent", float(value))
 
     elif name in ["funnellabelposition", "funnellabelsposition"]:
         if value in ["before", "after"]:
@@ -6074,10 +6077,6 @@ for lineNumber, line in enumerate(linesAfterConcatenation):
                     "pagesubtitlesize",
                     # Cards' vertical percent of content area
                     "cardpercent",
-                    # Card graphic's vertical or horizontal space
-                    "cardgraphicsize",
-                    # Card graphic padding
-                    "cardgraphicpadding",
                     # Base text size
                     "basetextsize",
                     # Base text decrement
@@ -6086,8 +6085,6 @@ for lineNumber, line in enumerate(linesAfterConcatenation):
                     "horizontalcardgap",
                     # Vertical card gap
                     "verticalcardgap",
-                    # Funnel label percentage
-                    "funnellabelspercent",
                 ]:
                     globals.processingOptions.dynamicallySetOption(
                         # Use the metadata key directly
@@ -6183,10 +6180,22 @@ for lineNumber, line in enumerate(linesAfterConcatenation):
                         metadataKey, metadataValue, ""
                     )
 
+                elif metadataKey == "cardgraphicsize":
+                    # Card graphic's vertical or horizontal space
+                    globals.processingOptions.dynamicallySetOption(
+                        "cardGraphicSize", metadataValue, "float"
+                    )
+
+                elif metadataKey == "cardgraphicpadding":
+                    # Card graphic padding
+                    globals.processingOptions.dynamicallySetOption(
+                        "cardGraphicPadding", metadataValue, "float"
+                    )
+
                 elif metadataKey == "cardgraphicposition":
                     # Card graphic position - before or after
                     globals.processingOptions.dynamicallySetOption(
-                        metadataKey, metadataValue, ""
+                        "cardGraphicPosition", metadataValue, ""
                     )
 
                 elif metadataKey == "cardshape":
@@ -6235,24 +6244,17 @@ for lineNumber, line in enumerate(linesAfterConcatenation):
                         "funnelColours", valueArray2, ""
                     )
 
-                elif metadataKey in [
-                    "funneltitlecolour",
-                    "funneltitlecolor",
-                    "funnelbordercolour",
-                    "funnelbordercolor",
-                    "funneltextcolour",
-                    "funneltextcolor",
-                ]:
-                    # Funnel single colour options
-                    funnelColourOption = funnelColourOptionName(metadataKey)
-                    if metadataValue in ["default", "pres", "pop", "prev"]:
-                        globals.processingOptions.dynamicallySetOption(
-                            funnelColourOption, metadataValue, ""
-                        )
-                    else:
-                        globals.processingOptions.dynamicallySetOption(
-                            funnelColourOption, parseColour(metadataValue.strip()), ""
-                        )
+                elif metadataKey in ["funneltitlecolour", "funneltitlecolor"]:
+                    # Funnel single title colour option
+                    dynamicallySetColourOption("funnelTitleColour", metadataValue)
+
+                elif metadataKey in ["funnelbordercolour", "funnelbordercolor"]:
+                    # Funnel single border colour option
+                    dynamicallySetColourOption("funnelBorderColour", metadataValue)
+
+                elif metadataKey in ["funneltextcolour", "funneltextcolor"]:
+                    # Funnel single text colour option
+                    dynamicallySetColourOption("funnelTextColour", metadataValue)
 
                 elif metadataKey == "backgroundimage":
                     # Slide background image
@@ -6397,6 +6399,12 @@ for lineNumber, line in enumerate(linesAfterConcatenation):
                         print(
                             f"Invalid value for {metadataKey}: {metadataValue} in '{line}"
                         )
+
+                elif metadataKey == "funnellabelspercent":
+                    # Funnel label percentage
+                    globals.processingOptions.dynamicallySetOption(
+                        "funnelLabelsPercent", metadataValue, "float"
+                    )
 
                 elif metadataKey in ["funnellabelposition", "funnellabelsposition"]:
                     if metadataValue.lower() in [

--- a/processingOptions.py
+++ b/processingOptions.py
@@ -4,6 +4,12 @@ processingOptions
 
 """
 
+
+# Splits a string into words, converting each word to an integer. Returns them as a
+# sorted list.
+def sortedNumericList(string: str) -> list[int]:
+    return sorted(list(map(int, set(string.split()))))
+
 # Note: Options stored with lower case keys
 class ProcessingOptions:
     def __init__(self):


### PR DESCRIPTION
I ran a torture test trying to understand the syntax and how the tool worked to evaluate it. (Love it BTW.) I found a couple places I needed to fix things I think. Mostly whitespace issues and casing issues.

  - canonical cardGraphic* option names for card metadata
  - support for additional funnel aliases such as funnellabelsposition and color-name variants
  - support for wholeTableLineStyling = both
  - TOC bullet flattening so nested bullet structures render correctly
  - normalized section-slide keys so TOC links resolve reliably even when titles have surrounding whitespace

