### PR TITLE
Fix metadata value containing a colon being mis-split

### DIFF
--- a/md2pptx
+++ b/md2pptx
@@ -4749,7 +4749,7 @@ slideNumber = 1
 
 bulletRegex = re.compile(r"^(\s)*(\*)(.*)")
 numberRegex = re.compile(r"^(\s)*(\d+)\.(.*)")
-metadataRegex = re.compile("^(.+):(.+)")
+metadataRegex = re.compile("^([^:]+):(.+)")
 
 graphicRE = r"!\[(.*?)\]\((.+?)\)"
 graphicRegex = re.compile(graphicRE)


### PR DESCRIPTION
### Problem

`metadataRegex` uses a greedy `(.+)` for the option name, so a metadata line is split at the **last** colon rather than the first. Any value that itself contains a colon is parsed into the wrong option name:

```
mathxsl: C:/Program Files/Microsoft Office/root/Office16/MML2OMML.XSL
  ->  name  = "mathxsl: C"
      value = "/Program Files/Microsoft Office/root/Office16/MML2OMML.XSL"
```

The mangled name matches no option branch, so the option is silently discarded — no warning, no error.

On Windows this affects **every path-valued option**, because absolute paths always contain a drive colon. `template:` silently falls back to the built-in template, and any option pointing at a file simply does nothing.

The bug has been present since the initial commit (`95e1a99`, 2020-09-26).

### Fix

Restrict the option name to non-colon characters:

```python
metadataRegex = re.compile("^([^:]+):(.+)")
```

### Verification

* None of the 118 option names handled in `md2pptx` contains a colon, so no existing name can be affected.
* Built `test/fullPresentation.md`, `test/codetest.md`, `test/cardTest.md` and `test/linktest.md` (79 slides total) before and after the change. Slide text, shape offsets and extents are identical in every case. (The comparison normalises the `Presentation built:` timestamp that md2pptx stamps on slide 1, which otherwise differs between any two runs.)
* With the fix, `template:` and `mathxsl:` given as Windows absolute paths are parsed correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)