### PR TITLE
Add footnotesOnSlide option to place citations at the foot of the citing slide

### DIFF
--- a/md2pptx
+++ b/md2pptx
@@ -1908,6 +1908,85 @@ def createAbstractSlide(presentation, slideNumber, titleText, paragraphs):
     return slide
 
 
+# A footnote reference [^ref] in body text. The definition line "[^ref]: ..."
+# is excluded by the negative lookahead.
+slideFootnoteRefRegex = re.compile(r"\[\^([^\]]+)\](?!:)")
+
+
+def collectStrings(obj, acc):
+    if isinstance(obj, str):
+        acc.append(obj)
+    elif isinstance(obj, (list, tuple)):
+        for o in obj:
+            collectStrings(o, acc)
+
+
+def slideFootnoteNumbers(slideInfo):
+    # Zero-based numbers of the footnotes cited on this slide, in order
+    acc = []
+    for part in (slideInfo.titleText, slideInfo.bullets, slideInfo.tableRows,
+                 slideInfo.cards):
+        collectStrings(part, acc)
+
+    numbers = []
+    for text in acc:
+        for ref in slideFootnoteRefRegex.findall(text):
+            if ref in globals.footnoteReferences:
+                n = globals.footnoteReferences.index(ref)
+                if n not in numbers:
+                    numbers.append(n)
+    return sorted(numbers)
+
+
+def slideFootnoteHeight(numbers, fontSize, widthEmu):
+    # Height in EMU the footnote block needs. Long definitions wrap onto
+    # several lines, so estimate the line count. Underestimating makes the
+    # block overlap the content, so assume few characters per line.
+    if not numbers:
+        return 0
+
+    widthPt = widthEmu / 12700
+    charsPerLine = max(20, int(widthPt / (fontSize * 0.50)))
+
+    lines = 0
+    for n in numbers:
+        text = "[" + str(n + 1) + "] " + globals.footnoteDefinitions[n][1]
+        lines += max(1, -(-len(text) // charsPerLine))
+
+    return int(Pt(fontSize * 1.30) * lines + Pt(4))
+
+
+def addSlideFootnotes(slide, numbers, left, width, top, fontSize):
+    # Lay the cited definitions out at the foot of the slide as "[n] text"
+    if not numbers:
+        return None
+
+    height = slideFootnoteHeight(numbers, fontSize, width)
+    box = slide.shapes.add_textbox(left, top, width, height)
+    tf = box.text_frame
+    tf.word_wrap = True
+    tf.margin_left = 0
+    tf.margin_right = 0
+    tf.margin_top = 0
+    tf.margin_bottom = 0
+
+    for i, n in enumerate(numbers):
+        p = tf.paragraphs[0] if i == 0 else tf.add_paragraph()
+        p.space_before = Pt(0)
+        p.space_after = Pt(0)
+        run = p.add_run()
+        run.text = "[" + str(n + 1) + "] " + globals.footnoteDefinitions[n][1]
+        run.font.size = Pt(fontSize)
+    return box
+
+
+def slideFootnotesFontSize():
+    # footnotesFontSize defaults to 0, meaning "leave the footnote slide's
+    # own text size alone". On-slide footnotes need a concrete size.
+    fontSize = globals.processingOptions.getCurrentOption("footnotesFontSize")
+    return fontSize if fontSize > 0 else 12
+
+
 # Unified creation of a table or a code or a content slide
 def createContentSlide(presentation, slideNumber, slideInfo):
     titleOnlyLayout = globals.processingOptions.getCurrentOption("titleOnlyLayout")
@@ -1962,6 +2041,19 @@ def createContentSlide(presentation, slideNumber, slideInfo):
     contentLeft, contentWidth, contentTop, contentHeight = getContentRect(
         presentation, slide, slideTitleBottom, marginBase
     )
+
+    ####################################################################
+    # If the cited footnotes are to go at the foot of this slide, take #
+    # the space they need out of the content area first. Adding them   #
+    # afterwards would overlap the content.                            #
+    ####################################################################
+    slideFootnotes = []
+    footnotesFontSize = slideFootnotesFontSize()
+    if globals.processingOptions.getCurrentOption("footnotesOnSlide") == "yes":
+        slideFootnotes = slideFootnoteNumbers(slideInfo)
+        contentHeight -= slideFootnoteHeight(
+            slideFootnotes, footnotesFontSize, contentWidth
+        )
 
     ####################################################################
     # Check whether there are too many elements in the sequence to     #
@@ -2019,6 +2111,16 @@ def createContentSlide(presentation, slideNumber, slideInfo):
         else:
             createCodeBlock(slideInfo, slide, renderingRectangle, codeBlockNumber)
             codeBlockNumber += 1
+
+    if slideFootnotes:
+        addSlideFootnotes(
+            slide,
+            slideFootnotes,
+            contentLeft,
+            contentWidth,
+            contentTop + contentHeight + Pt(4),
+            footnotesFontSize,
+        )
 
     if want_numbers_content is True:
         addFooter(presentation, slideNumber, slide)
@@ -5044,7 +5146,14 @@ globals.processingOptions.setOptionValuesArray(
 
 # Footnotes defaults
 globals.processingOptions.setOptionValuesArray(
-    [["footnotesTitle", "Footnotes"], ["footnotesPerPage", 20], ["footnotesFontSize", 0]]
+    [
+        ["footnotesTitle", "Footnotes"],
+        ["footnotesPerPage", 20],
+        ["footnotesFontSize", 0],
+        # "yes" places the cited footnotes at the foot of each citing slide,
+        # as "[n] text", instead of collecting them onto footnote slides.
+        ["footnotesOnSlide", "no"],
+    ]
 )
 
 # Table Of Contents defaults
@@ -5546,6 +5655,9 @@ for line in metadata_lines:
 
     elif name == "footnotesfontsize":
         globals.processingOptions.setOptionValues(name, float(value))
+
+    elif name == "footnotesonslide":
+        globals.processingOptions.setOptionValues(name, value.lower())
 
     elif name == "footnotestitle":
         globals.processingOptions.setOptionValues(name, value)
@@ -6796,7 +6908,10 @@ if (inBlock is True) | (inCode is True) | (inTable is True):
 # Add a footnotes slide - if there were any footnote definitions                     #
 #                                                                                    #
 ######################################################################################
-if len(globals.footnoteDefinitions) > 0:
+if (
+    len(globals.footnoteDefinitions) > 0
+    and globals.processingOptions.getCurrentOption("footnotesOnSlide") != "yes"
+):
     slideNumber, footnoteSlides = createFootnoteSlides(
         prs, slideNumber, globals.footnoteDefinitions
     )

--- a/md2pptx
+++ b/md2pptx
@@ -1912,6 +1912,11 @@ def createAbstractSlide(presentation, slideNumber, titleText, paragraphs):
 # is excluded by the negative lookahead.
 slideFootnoteRefRegex = re.compile(r"\[\^([^\]]+)\](?!:)")
 
+# Footnote numbers already written out at the foot of an earlier slide.
+# Slides are created in document order, so membership here means "the reader
+# has already been given this definition".
+slideFootnotesAlreadyShown = set()
+
 
 def collectStrings(obj, acc):
     if isinstance(obj, str):
@@ -2050,7 +2055,14 @@ def createContentSlide(presentation, slideNumber, slideInfo):
     slideFootnotes = []
     footnotesFontSize = slideFootnotesFontSize()
     if globals.processingOptions.getCurrentOption("footnotesOnSlide") == "yes":
-        slideFootnotes = slideFootnoteNumbers(slideInfo)
+        # A definition is written out only on the slide that cites it first.
+        # Later slides show the bracketed number on its own, as a reader who
+        # has seen the definition once does not need it repeated.
+        slideFootnotes = [
+            n for n in slideFootnoteNumbers(slideInfo)
+            if n not in slideFootnotesAlreadyShown
+        ]
+        slideFootnotesAlreadyShown.update(slideFootnotes)
         contentHeight -= slideFootnoteHeight(
             slideFootnotes, footnotesFontSize, contentWidth
         )

--- a/md2pptx
+++ b/md2pptx
@@ -5676,7 +5676,12 @@ for line in metadata_lines:
         globals.processingOptions.setOptionValues(name, float(value))
 
     elif name == "footnotesonslide":
-        globals.processingOptions.setOptionValues(name, value.lower())
+        if value.lower() in ["yes", "no"]:
+            globals.processingOptions.setOptionValues(name, value.lower())
+        else:
+            print(
+                f'FootnotesOnSlide value \'{value}\' unsupported. "yes" or "no" required.'
+            )
 
     elif name == "footnotestitle":
         globals.processingOptions.setOptionValues(name, value)

--- a/md2pptx
+++ b/md2pptx
@@ -1917,6 +1917,12 @@ slideFootnoteRefRegex = re.compile(r"\[\^([^\]]+)\](?!:)")
 # has already been given this definition".
 slideFootnotesAlreadyShown = set()
 
+# Gap between the bottom of the content and the top of the footnote block.
+# Counted once, in what is taken out of the content rectangle and again when
+# the block is positioned, so the block ends exactly where the content would
+# have ended and never reaches into the slide number band below it.
+slideFootnoteGap = Pt(4)
+
 
 def collectStrings(obj, acc):
     if isinstance(obj, str):
@@ -1958,7 +1964,7 @@ def slideFootnoteHeight(numbers, fontSize, widthEmu):
         text = "[" + str(n + 1) + "] " + globals.footnoteDefinitions[n][1]
         lines += max(1, -(-len(text) // charsPerLine))
 
-    return int(Pt(fontSize * 1.30) * lines + Pt(4))
+    return int(Pt(fontSize * 1.30) * lines)
 
 
 def addSlideFootnotes(slide, numbers, left, width, top, fontSize):
@@ -2063,9 +2069,10 @@ def createContentSlide(presentation, slideNumber, slideInfo):
             if n not in slideFootnotesAlreadyShown
         ]
         slideFootnotesAlreadyShown.update(slideFootnotes)
-        contentHeight -= slideFootnoteHeight(
-            slideFootnotes, footnotesFontSize, contentWidth
-        )
+        if slideFootnotes:
+            contentHeight -= slideFootnoteGap + slideFootnoteHeight(
+                slideFootnotes, footnotesFontSize, contentWidth
+            )
 
     ####################################################################
     # Check whether there are too many elements in the sequence to     #
@@ -2130,7 +2137,7 @@ def createContentSlide(presentation, slideNumber, slideInfo):
             slideFootnotes,
             contentLeft,
             contentWidth,
-            contentTop + contentHeight + Pt(4),
+            contentTop + contentHeight + slideFootnoteGap,
             footnotesFontSize,
         )
 

--- a/paragraph.py
+++ b/paragraph.py
@@ -626,7 +626,15 @@ def addFormattedText(p, text):
                 fnref = fragment[1]
                 if fnref in globals.footnoteReferences:
                     footnoteNumber = globals.footnoteReferences.index(fnref)
-                    run.text = str(footnoteNumber + 1)
+                    if (
+                        globals.processingOptions.getCurrentOption("footnotesOnSlide")
+                        == "yes"
+                    ):
+                        # The definitions are laid out as "[n] text" at the foot
+                        # of the slide, so bracket the reference to match
+                        run.text = "[" + str(footnoteNumber + 1) + "]"
+                    else:
+                        run.text = str(footnoteNumber + 1)
                     # Support multiple runs per footnote reference
                     if footnoteNumber not in globals.footnoteRunsDictionary:
                         globals.footnoteRunsDictionary[footnoteNumber] = []


### PR DESCRIPTION
Adds a `footnotesOnSlide` metadata option. With `yes`, the footnotes a slide cites are laid out at the foot of that slide as `[n] text`, and the footnote slides at the end are not generated. Body references are bracketed to match. The default is `no`, so nothing changes unless it is asked for.

The case for it is the short talk: the audience cannot page forward to a references slide, so a source is only useful if it is readable next to the claim it supports.

## Behaviour

A definition is written out **only on the slide that cites it first**. Later slides that cite it again show the bracketed number on its own. Repeating the definition would cost vertical space on every citing slide, and a reader who has already been given it does not need it again.

Space for the block is taken out of the content rectangle before the blocks are rendered, since adding it afterwards would overlap the content. The height allows for definitions wrapping onto several lines.

`footnotesFontSize` keeps its current default of 0, meaning "leave the footnote slide's own text alone". On-slide footnotes need a concrete size, so 12 is used when it is 0.

## Verification

With the option unset, `Three-Item-Slide`, `XMLtest`, `cardTest`, `codetest`, `fullPresentation`, `linktest`, `twoGraphics`, `twoLists` and `videoSlide` build identically to `main` — slide text, shape offsets and shape extents all match. (The comparison normalises the `Presentation built:` timestamp on slide 1.) `linktest.md` is the only bundled deck that uses footnotes, so it is the one that carries weight there.

With `footnotesOnSlide: yes`, `linktest.md` goes from three slides to two: the `Footnotes` slide is gone and the definition appears at the foot of the slide that cites it. I checked that the same comparison does report a difference in that case, so the nine matches above are not simply the comparison failing to look.

## Documentation

None included — I have left the User Guide alone. The description above is the whole of the behaviour if you want it for the `.mdp`.
