### PR TITLE
Add install-directory fallback for math stylesheet

### DIFF
--- a/docs/latex.mdp
+++ b/docs/latex.mdp
@@ -1,10 +1,10 @@
 ### LaTeX
 <a id="latex"></a>
 
-To use md2pptx's in-built LaTeX support you must have latex2mathml installed and specify the converter stylesheet you are going to use.
+To use md2pptx's in-built LaTeX support you must have latex2mathml installed and a converter stylesheet available.
 This stylesheet is generally obtained from a Microsoft Office installation.
 Its name is usually `MML2OMML.XSL`.
-Specify its location with
+Copy it to the md2pptx install directory as `mml2omml.xsl`, or specify its location with
 
     mathxsl: ~/md2pptx/MML2OMML.XSL
 

--- a/docs/user-guide.html
+++ b/docs/user-guide.html
@@ -3081,10 +3081,10 @@ for(i = 0; i &lt; 10; i++){
 </ol>
 <h3 id="latex">LaTeX<a class="headerlink" href="#latex" title="Permanent link"></a></h3>
 <p><a id="latex"></a></p>
-<p>To use md2pptx&rsquo;s in-built LaTeX support you must have latex2mathml installed and specify the converter stylesheet you are going to use.
+<p>To use md2pptx&rsquo;s in-built LaTeX support you must have latex2mathml installed and a converter stylesheet available.
 This stylesheet is generally obtained from a Microsoft Office installation.
 Its name is usually <code>MML2OMML.XSL</code>.
-Specify its location with</p>
+Copy it to the md2pptx install directory as <code>mml2omml.xsl</code>, or specify its location with</p>
 <pre><code>mathxsl: ~/md2pptx/MML2OMML.XSL
 </code></pre>
 <p>If the prerequisites are met you can code equations such as</p>
@@ -4577,11 +4577,12 @@ You can instead instruct it to place footnotes at the bottom of the slides they 
 <p>The default is <code>no</code>.</p>
 <p><a id="latex-stylesheet-location-mathxsl"></a></p>
 <h4 id="latex-stylesheet-location-mathxsl">LATeX Stylesheet Location - <code>mathxsl</code><a class="headerlink" href="#latex-stylesheet-location-mathxsl" title="Permanent link"></a></h4>
-<p>As described in <a href="#latex">LaTeX</a>, you need to specify the stylesheet location if you are to use the function.
-Here is an example:</p>
+<p>As described in <a href="#latex">LaTeX</a>, md2pptx needs a copy of the MML2OMML stylesheet to use this function.
+By default it looks for <code>mml2omml.xsl</code> in the md2pptx install directory.
+You can specify a different location with, for example:</p>
 <pre><code>mathxsl: ~/md2pptx/MML2OMML.XSL
 </code></pre>
-<p><strong>Note:</strong> It&rsquo;s probably a good idea to keep the stylesheet safe and copy it into the md2pptx directory after installing md2pptx - if that&rsquo;s where you use it.</p>
+<p>If the specified file does not exist, md2pptx also tries the install-directory copy as a fallback.</p>
 <p><a id="slide-heading-levels-topheadinglevel"></a></p>
 <h4 id="slide-heading-levels-topheadinglevel">Slide Heading Levels - <code>TopHeadingLevel</code><a class="headerlink" href="#slide-heading-levels-topheadinglevel" title="Permanent link"></a></h4>
 <p>The usual heading levels for different types of slides are as follows:</p>

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1353,10 +1353,10 @@ Each row leads to a funnel stage. The first column is the text for the label abo
 ### LaTeX
 <a id="latex"></a>
 
-To use md2pptx's in-built LaTeX support you must have latex2mathml installed and specify the converter stylesheet you are going to use.
+To use md2pptx's in-built LaTeX support you must have latex2mathml installed and a converter stylesheet available.
 This stylesheet is generally obtained from a Microsoft Office installation.
 Its name is usually `MML2OMML.XSL`.
-Specify its location with
+Copy it to the md2pptx install directory as `mml2omml.xsl`, or specify its location with
 
     mathxsl: ~/md2pptx/MML2OMML.XSL
 
@@ -3184,12 +3184,13 @@ The default is `no`.
 <a id="latex-stylesheet-location-mathxsl"></a>
 #### LATeX Stylesheet Location - `mathxsl`
 
-As described in [LaTeX](#latex), you need to specify the stylesheet location if you are to use the function.
-Here is an example:
+As described in [LaTeX](#latex), md2pptx needs a copy of the MML2OMML stylesheet to use this function.
+By default it looks for `mml2omml.xsl` in the md2pptx install directory.
+You can specify a different location with, for example:
 
     mathxsl: ~/md2pptx/MML2OMML.XSL
 
-**Note:** It's probably a good idea to keep the stylesheet safe and copy it into the md2pptx directory after installing md2pptx - if that's where you use it.
+If the specified file does not exist, md2pptx also tries the install-directory copy as a fallback.
 
 <a id="slide-heading-levels-topheadinglevel"></a>
 #### Slide Heading Levels - `TopHeadingLevel`

--- a/docs/user-guide.mdp
+++ b/docs/user-guide.mdp
@@ -3022,12 +3022,13 @@ The default is `no`.
 <a id="latex-stylesheet-location-mathxsl"></a>
 #### LATeX Stylesheet Location - `mathxsl`
 
-As described in [LaTeX](#latex), you need to specify the stylesheet location if you are to use the function.
-Here is an example:
+As described in [LaTeX](#latex), md2pptx needs a copy of the MML2OMML stylesheet to use this function.
+By default it looks for `mml2omml.xsl` in the md2pptx install directory.
+You can specify a different location with, for example:
 
     mathxsl: ~/md2pptx/MML2OMML.XSL
 
-**Note:** It's probably a good idea to keep the stylesheet safe and copy it into the md2pptx directory after installing md2pptx - if that's where you use it.
+If the specified file does not exist, md2pptx also tries the install-directory copy as a fallback.
 
 <a id="slide-heading-levels-topheadinglevel"></a>
 #### Slide Heading Levels - `TopHeadingLevel`

--- a/pptx_math.py
+++ b/pptx_math.py
@@ -180,6 +180,39 @@ def _hoist_math_namespaces(shape) -> None:
 
 # ── MathInserter ──────────────────────────────────────────────────────────────
 
+def _resolve_mathxsl_path(
+    configured_path: str | Path | None,
+    fallback_path: str | Path | None = None,
+) -> Path:
+    """Return the configured stylesheet or the copy beside md2pptx.
+
+    A user-supplied path takes precedence.  If it is absent or no ``mathxsl``
+    option was supplied, look for ``mml2omml.xsl`` in the installation
+    directory.
+    """
+    fallback = (
+        Path(fallback_path).expanduser()
+        if fallback_path is not None
+        else Path(__file__).resolve().with_name("mml2omml.xsl")
+    )
+
+    configured = Path(configured_path).expanduser() if configured_path else None
+    if configured is not None and configured.is_file():
+        return configured
+    if fallback.is_file():
+        return fallback
+
+    if configured is not None:
+        raise FileNotFoundError(
+            f"MML2OMML.XSL not found: {configured}; "
+            f"installation-directory fallback not found: {fallback}"
+        )
+    raise FileNotFoundError(
+        f"mathxsl option not set and installation-directory fallback "
+        f"not found: {fallback}"
+    )
+
+
 class MathInserter:
     def __init__(self, xsl_path: str | Path):
         xsl_path = Path(xsl_path)
@@ -216,12 +249,10 @@ class PptxMath:
         pass
 
     def run(self, prs, slide, renderingRectangle, codeLines, codeType):
-        mathxsl_path = globals.processingOptions.getCurrentOption("mathxsl")
-        if not mathxsl_path:
-            sys.stderr.write("Math block skipped: mathxsl option not set.\n")
-            return
-
         try:
+            mathxsl_path = _resolve_mathxsl_path(
+                globals.processingOptions.getCurrentOption("mathxsl")
+            )
             inserter = MathInserter(mathxsl_path)
         except Exception as e:
             sys.stderr.write(f"Math block skipped: {e}\n")

--- a/test/test_pptx_math.py
+++ b/test/test_pptx_math.py
@@ -1,0 +1,70 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import pptx_math
+from pptx_math import _resolve_mathxsl_path
+
+
+class ResolveMathXslPathTests(unittest.TestCase):
+    def test_prefers_configured_stylesheet(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            configured = root / "custom.xsl"
+            fallback = root / "mml2omml.xsl"
+            configured.touch()
+            fallback.touch()
+
+            self.assertEqual(
+                _resolve_mathxsl_path(configured, fallback),
+                configured,
+            )
+
+    def test_uses_install_directory_fallback_when_configured_path_is_missing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            configured = root / "missing.xsl"
+            fallback = root / "mml2omml.xsl"
+            fallback.touch()
+
+            self.assertEqual(
+                _resolve_mathxsl_path(configured, fallback),
+                fallback,
+            )
+
+    def test_uses_install_directory_fallback_when_option_is_not_set(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fallback = Path(directory) / "mml2omml.xsl"
+            fallback.touch()
+
+            self.assertEqual(
+                _resolve_mathxsl_path(None, fallback),
+                fallback,
+            )
+
+    def test_default_fallback_is_beside_pptx_math_module(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fallback = root / "mml2omml.xsl"
+            fallback.touch()
+
+            with mock.patch.object(pptx_math, "__file__", str(root / "pptx_math.py")):
+                self.assertEqual(_resolve_mathxsl_path(None), fallback)
+
+    def test_reports_configured_and_fallback_paths_when_neither_exists(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            configured = root / "missing.xsl"
+            fallback = root / "mml2omml.xsl"
+
+            with self.assertRaises(FileNotFoundError) as caught:
+                _resolve_mathxsl_path(configured, fallback)
+
+            message = str(caught.exception)
+            self.assertIn(str(configured), message)
+            self.assertIn(str(fallback), message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- use `mml2omml.xsl` beside `pptx_math.py` when `mathxsl` is unset
- use the same install-directory copy when a configured stylesheet path is missing
- keep a valid configured path as the first choice
- document the fallback and add focused path-resolution tests

## Tests

- `.venv/Scripts/python -m unittest discover -s test -p "test*.py" -v`
- `.venv/Scripts/python -m compileall -q .`
- `git diff --check`

Closes #236