### PR TITLE
Add inline maths with $`LaTeX`$

### DIFF
--- a/paragraph.py
+++ b/paragraph.py
@@ -7,13 +7,107 @@ from pptx.enum.shapes import PP_PLACEHOLDER
 from lxml import etree
 from pptx.oxml.xmlchemy import OxmlElement
 import re
+import sys
 from pptx.dml.color import RGBColor, MSO_THEME_COLOR
 from pptx.util import Pt
 
 import globals
+import pptx_math
 from processingOptions import *
 from symbols import resolveSymbols
 from colour import *
+
+# Inline maths: $`LaTeX`$ inside body text. Block maths already had a handler
+# (``` math fenced blocks -> pptx_math.PptxMath), but there was no way to put a
+# symbol inside a sentence, so authors had to spell "L_patch" in plain text.
+#
+# The delimiters are GitHub's, and deliberately not a bare "$". parseText below
+# rewrites the line before tokenising it, and the tokeniser then drops "*" and
+# "[" whenever they match none of its cases - even inside a code span - so LaTeX
+# left in the line does not survive. Requiring a backtick against the dollar
+# also keeps "costs $5 to $10" out of it.
+#
+# The LaTeX may not contain a backtick. GitHub's inner delimiters are a code
+# span, which cannot contain one either, and allowing it lets an unclosed opener
+# pair with the closing delimiter of the *next* formula and swallow the prose in
+# between.
+inlineMathRegex = re.compile(r"(?<!\\)\$`([^`]+)`\$")
+
+# Each formula is lifted out of the line and replaced by this one character.
+# FDD0-FDEF are permanent Unicode noncharacters, so they cannot occur in the
+# author's text. FDD0-FDE3 are already taken by the constructs parseText handles.
+mathSentinel = u"\uFDE4"
+
+# Anything in this range is one of the sentinels above, already substituted into
+# the text before parseText saw it. The section title, presentation title and
+# presentation subtitle routes resolveSymbols() their text before handing it over,
+# so a "\`" or an entity reference inside a formula arrives as a noncharacter.
+# Converting that buries an unreadable character in the OMML, so such a formula
+# is left as its source.
+substitutedSentinelRegex = re.compile("[\uFDD0-\uFDEF]")
+
+# The tokeniser states in which a formula can become a fragment of its own.
+# Everything else builds its fragment up as structure that a fragment boundary
+# would break - link text, a footnote reference - so those keep the literal
+# source instead. Listing what is allowed rather than what is not means a state
+# added later degrades to visible text rather than corrupting the fragment.
+mathFragmentStates = [
+    "N", "I", "B1", "B2", "C",
+    "CMRep", "CMHig", "CMCom", "CMDel", "CMAdd",
+    "Ins", "Del", "Sub", "Sup",
+]
+
+# Compiling the XSLT is slow, so keep one inserter per mathxsl option value.
+_mathInserterCache = {}
+
+
+def getMathInserter():
+    """MathInserter for the resolved stylesheet, or None if there is not one.
+
+    _resolve_mathxsl_path takes the mathxsl option when it names a file and
+    falls back to the copy beside pptx_math.py, so inline maths becomes
+    available on exactly the same terms as a ``` math block.
+    """
+    configured = globals.processingOptions.getCurrentOption("mathxsl")
+    if configured not in _mathInserterCache:
+        try:
+            _mathInserterCache[configured] = pptx_math.MathInserter(
+                pptx_math._resolve_mathxsl_path(configured)
+            )
+        except Exception as e:
+            sys.stderr.write(f"Inline math skipped: {e}\n")
+            _mathInserterCache[configured] = None
+    return _mathInserterCache[configured]
+
+
+def inlineMathSource(latex):
+    """The literal "$`...`$" the author wrote, rebuilt from its LaTeX."""
+    return "$`" + latex + "`$"
+
+
+def emitInlineMath(p, latex):
+    """Append `latex` to paragraph `p` as one inline OMML equation.
+
+    pptx_math.inject_inline_math appends to the paragraph, so calling it
+    between add_run() calls keeps the reading order.
+
+    A formula that will not convert is left as its literal "$`...`$" source
+    rather than dropped: a symbol silently missing from the middle of a
+    sentence is far harder to notice than a stray dollar sign.
+    """
+    inserter = getMathInserter()
+    omath = None
+    if inserter is not None:
+        try:
+            omath = inserter.make_inline_omml(latex)
+        except Exception as e:
+            sys.stderr.write(f"Inline math conversion failed for '{latex}': {e}\n")
+
+    if omath is None:
+        p.add_run().text = inlineMathSource(latex)
+    else:
+        pptx_math.inject_inline_math(p._p, omath)
+
 
 # Following functions are workarounds for python-pptx not having these functions for the font object
 def setSubscript(font):
@@ -100,6 +194,32 @@ def parseText(text):
     fragment = ""
     lastChar = ""
     spanState = "None"
+
+    # A span reads a class name or style, then ">", then its text, and an abbr
+    # reads a title the same way; both split the accumulated fragment when they
+    # close. Emitting a formula part way through would shorten that split and
+    # raise IndexError, so formulae stay as source text while one is being read.
+    # spanState cannot serve here: the "<span style=" case only sets it when the
+    # fragment is already non-empty, so a span at the start of a line misses it.
+    structuralFragment = False
+
+    # Lift any inline formulae out of the line before the replacements below can
+    # touch them, leaving one sentinel character behind for each. "\[" and "\_"
+    # would be rewritten, and the tokeniser drops "*" and "[" outright, so LaTeX
+    # left in the line does not reach the fragment it belongs to intact.
+    # Testing the line first keeps the cost off the lines that have no formula,
+    # and means a presentation without a stylesheet is never told about one.
+    mathSpans = []
+    mathIndex = 0
+    if inlineMathRegex.search(text) and getMathInserter() is not None:
+        def stashMath(match):
+            if substitutedSentinelRegex.search(match.group(1)):
+                return match.group(0)
+
+            mathSpans.append(match.group(1))
+            return mathSentinel
+
+        text = inlineMathRegex.sub(stashMath, text)
 
     # Replace any "\#" strings with entity reference
     text2 = text.replace("\\#", "&#x23;")
@@ -448,6 +568,26 @@ def parseText(text):
             else:
                 fragment = fragment + c
 
+        elif c == mathSentinel:
+            latex = mathSpans[mathIndex]
+            mathIndex += 1
+
+            if structuralFragment or state not in mathFragmentStates:
+                # The fragment being built carries structure that a formula would
+                # break: link text, a footnote reference, a span's class name or
+                # a glossary title. Leave the source as text instead.
+                fragment = fragment + inlineMathSource(latex)
+
+            else:
+                if fragment != "":
+                    # Bold accumulates as "B1" and is only emitted as "B2" when
+                    # the closing "**" arrives. Flushing it as "B1" would lose
+                    # the bold, as addFormattedText has no case for "B1".
+                    textArray.append(["B2" if state == "B1" else state, fragment])
+                    fragment = ""
+
+                textArray.append(["Math", latex])
+
         elif c == u"\uFDE3":
             fragment = fragment + "`"
 
@@ -461,6 +601,7 @@ def parseText(text):
             fragment = fragment + "]"
 
         elif c == u"\uFDD5":
+            structuralFragment = False
             dictEntry = fragment.split(">")
             dictAbbrev = dictEntry[1]
             dictFull = dictEntry[0].strip().strip("'").strip('"')
@@ -469,6 +610,7 @@ def parseText(text):
             fragment = ""
 
         elif c == u"\uFDD4":
+            structuralFragment = True
             if fragment != "":
                 textArray.append([state, fragment])
                 fragment = ""
@@ -476,6 +618,7 @@ def parseText(text):
 
         elif c == u"\uFDD3":
             # End of span
+            structuralFragment = False
             if spanState == "Class":
                 # Span with class
                 splitting = fragment.split(">")
@@ -513,6 +656,7 @@ def parseText(text):
 
         elif c == u"\uFDD2":
             # In span element where we hit the class name
+            structuralFragment = True
             if fragment != "":
                 textArray.append([state, fragment])
 
@@ -521,6 +665,7 @@ def parseText(text):
 
         elif c == u"\uFDD1":
             # In span element where we hit the style text
+            structuralFragment = True
             if fragment != "":
                 textArray.append([state, fragment])
 
@@ -569,6 +714,13 @@ def addFormattedText(p, text):
             fragType, fragDetail, fragTerm, fragTitle = fragment
         else:
             fragType, fragDetail = fragment
+
+        # A formula is emitted whole. Splitting it on a newline, or running the
+        # entity substitutions below over it, would corrupt its LaTeX.
+        if fragType == "Math":
+            emitInlineMath(p, fragDetail)
+            flattenedText = flattenedText + fragDetail
+            continue
 
         # Break into subfragments around a newline
         if fragType == "SpanClass":

--- a/test/mathTest.md
+++ b/test/mathTest.md
@@ -1,0 +1,42 @@
+template: Martin Template.pptx
+baseTextSize: 20
+
+# Math Test
+Inline and block maths
+
+### Inline Maths
+
+Inline maths uses GitHub's second inline form: a dollar, a backtick, the LaTeX, a
+backtick, a dollar. As with a block, nothing happens unless a stylesheet is
+available - either beside md2pptx as mml2omml.xsl or named by mathxsl.
+
+* The Euler identity $`e^{i\pi}+1=0`$ sits in the middle of a sentence
+* Multiplication $`a*b`$ and a power $`x**2`$ keep their asterisks
+* A bracketed fraction $`\left[\frac{a}{b}\right]`$ keeps its brackets
+* Backslash escapes survive: $`f\_g`$ and $`\#\{x\}`$
+* **Bold on either side of $`\mathcal{L}_{\text{patch}}`$ stays bold**
+* *Italic either side of $`\lambda`$ stays italic*
+* A sum with limits: $`\sum_{i=1}^{n} x_i^2`$
+* A matrix: $`\begin{bmatrix}1 & 2 \\ 3 & 4\end{bmatrix}`$
+* A bare dollar is not a delimiter, so costs $5 to $10 is left alone
+* Neither is one in a link: [$`x`$](https://example.com) stays as source
+
+### Inline Maths In A Table
+
+A row is split on "|" before the text is parsed, so a formula in a cell has to
+spell the bars as \vert or \mid.
+
+| Symbol | Meaning |
+|--------|---------|
+| $`\left\vert x \right\vert`$ | absolute value |
+| $`P(A \mid B)`$ | conditional probability |
+
+### Block Maths
+
+```math
+\mathcal{L} = \mathcal{L}_{\text{patch}} + \lambda \mathcal{L}_{\text{glob}}
+```
+
+```math 1.2.4
+\frac{-b \pm \sqrt{b^2-4ac}}{2a}
+```

--- a/test/test_inline_math.py
+++ b/test/test_inline_math.py
@@ -1,0 +1,249 @@
+"""Tokenising of inline maths - $`LaTeX`$ - in paragraph.parseText.
+
+parseText rewrites a line before it tokenises it ("\\#" to an entity reference,
+"\\[" to a sentinel, "\\_" to "_") and the tokeniser then drops "*" and "[" when
+they match none of its cases, even inside a code span.  LaTeX left in the line
+therefore does not survive: "a*b" loses its asterisk, "\\left[" loses its
+bracket, and "x**2" closes the code span it is sitting in.
+
+So a formula is lifted out of the line before any of that runs and replaced by a
+sentinel.  These tests pin that down, and pin down the places where a formula is
+deliberately left as source text instead.
+"""
+
+import contextlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import globals
+import paragraph
+import pptx_math
+from symbols import resolveSymbols
+
+# MathInserter only compiles the stylesheet it is given, and these tests stop at
+# the fragment list without converting anything, so a stylesheet that compiles is
+# enough.  MML2OMML.XSL itself ships with Office and cannot be redistributed.
+MINIMAL_XSL = """<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/"/>
+</xsl:stylesheet>
+"""
+
+
+def formulae(text):
+    """The LaTeX of each formula parseText found, in order."""
+    return [f[1] for f in paragraph.parseText(text) if f[0] == "Math"]
+
+
+class InlineMathTestCase(unittest.TestCase):
+    def setUp(self):
+        self._directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self._directory.cleanup)
+
+        stylesheet = Path(self._directory.name) / "mml2omml.xsl"
+        stylesheet.write_text(MINIMAL_XSL, encoding="utf-8")
+        self.stylesheet = stylesheet
+
+        globals.processingOptions.setOptionValues("mathxsl", str(stylesheet))
+        paragraph._mathInserterCache.clear()
+        self.addCleanup(paragraph._mathInserterCache.clear)
+        self.addCleanup(
+            globals.processingOptions.setOptionValues, "mathxsl", ""
+        )
+
+
+class LaTeXSurvivesTests(InlineMathTestCase):
+    """Characters parseText would otherwise rewrite or drop."""
+
+    def test_formula_becomes_its_own_fragment(self):
+        self.assertEqual(formulae(r"$`e^{i\pi}+1=0`$"), [r"e^{i\pi}+1=0"])
+
+    def test_single_asterisk_survives(self):
+        self.assertEqual(formulae(r"$`a*b`$"), [r"a*b"])
+
+    def test_double_asterisk_survives(self):
+        self.assertEqual(formulae(r"$`x**2`$"), [r"x**2"])
+
+    def test_square_bracket_survives(self):
+        self.assertEqual(
+            formulae(r"$`\left[\frac{a}{b}\right]`$"),
+            [r"\left[\frac{a}{b}\right]"],
+        )
+
+    def test_escaped_underscore_survives(self):
+        self.assertEqual(formulae(r"$`f\_g`$"), [r"f\_g"])
+
+    def test_escaped_hash_survives(self):
+        self.assertEqual(formulae(r"$`\#\{x\}`$"), [r"\#\{x\}"])
+
+    def test_surrounding_text_keeps_its_place(self):
+        self.assertEqual(
+            paragraph.parseText(r"before $`x`$ after"),
+            [["N", "before "], ["Math", "x"], ["N", " after"]],
+        )
+
+    def test_several_formulae_keep_their_order(self):
+        self.assertEqual(formulae(r"$`a`$ and $`b`$"), ["a", "b"])
+
+
+class DelimiterTests(InlineMathTestCase):
+    def test_currency_is_not_a_formula(self):
+        """A bare "$" is not a delimiter, so this line is untouched."""
+        self.assertEqual(
+            paragraph.parseText("costs $5 to $10"), [["N", "costs $5 to $10"]]
+        )
+
+    def test_unclosed_opener_does_not_swallow_the_next_formula(self):
+        """The LaTeX may not contain a backtick, so an unclosed opener cannot
+        pair with the closing delimiter of the formula after it."""
+        self.assertEqual(formulae(r"unclosed $` then text $`y`$ after"), ["y"])
+
+    def test_escaped_dollar_inside_a_formula_survives(self):
+        """GitHub documents this form, so "$" stays legal inside the LaTeX."""
+        self.assertEqual(formulae(r"$`\sqrt{\$4}`$"), [r"\sqrt{\$4}"])
+
+    def test_escaped_delimiter_is_not_a_formula(self):
+        self.assertEqual(formulae(r"\$`x`$"), [])
+
+    def test_unclosed_formula_is_left_alone(self):
+        self.assertEqual(formulae(r"$`x`"), [])
+
+
+class EmphasisTests(InlineMathTestCase):
+    def test_bold_either_side_of_a_formula_stays_bold(self):
+        """Bold accumulates as "B1" and is only emitted as "B2" when the closing
+        "**" arrives, so the run before the formula has to be flushed as "B2"."""
+        fragments = paragraph.parseText(r"**bold $`x`$ more**")
+        self.assertIn(["B2", "bold "], fragments)
+        self.assertIn(["B2", " more"], fragments)
+        self.assertEqual(formulae(r"**bold $`x`$ more**"), ["x"])
+
+    def test_italic_either_side_of_a_formula_stays_italic(self):
+        """Italic needs no mapping: it accumulates as "I" and is emitted as "I".
+
+        Bold does need one, which is why the two cases are both here.
+        """
+        fragments = paragraph.parseText(r"*italic $`x`$ more*")
+        self.assertIn(["I", "italic "], fragments)
+        self.assertIn(["I", " more"], fragments)
+        self.assertEqual(formulae(r"*italic $`x`$ more*"), ["x"])
+
+    def test_formula_in_superscript_is_still_a_formula(self):
+        self.assertEqual(formulae(r"<sup>$`x`$</sup>"), ["x"])
+
+    def test_formula_in_criticmarkup_is_still_a_formula(self):
+        self.assertEqual(formulae(r"{++$`x`$++}"), ["x"])
+
+
+class StructuredFragmentTests(InlineMathTestCase):
+    """A span, an abbr and a link read their fragment as structure.
+
+    Each accumulates "something, a separator, then the text" and splits it when
+    it closes, so a formula emitted part way through shortens the split.  These
+    formulae are left as source text.
+    """
+
+    def test_formula_in_link_text_is_left_as_source(self):
+        fragments = paragraph.parseText(r"[$`x`$](url)")
+        self.assertEqual(formulae(r"[$`x`$](url)"), [])
+        self.assertTrue(
+            any(f[0] == "Link" and r"$`x`$" in f[1] for f in fragments)
+        )
+
+    def test_formula_in_link_url_is_left_as_source(self):
+        fragments = paragraph.parseText(r"[text]($`x`$)")
+        self.assertEqual(formulae(r"[text]($`x`$)"), [])
+        self.assertTrue(
+            any(f[0] == "Link" and r"$`x`$" in f[1] for f in fragments)
+        )
+
+    def test_formula_in_a_styled_span_is_left_as_source(self):
+        """The "<span style=" case only sets spanState once the fragment is
+        non-empty, so a span at the start of a line needs its own flag."""
+        source = r'<span style="color:red">$`x`$</span>'
+        self.assertEqual(formulae(source), [])
+        self.assertEqual(
+            paragraph.parseText(source),
+            [["SpanStyle", ["color:red", r"$`x`$"]]],
+        )
+
+    def test_formula_in_an_abbr_title_keeps_the_title(self):
+        source = r'<abbr title="$`x`$">A</abbr>'
+        self.assertEqual(
+            paragraph.parseText(source)[-1], ["Gloss", "A", "A", r"$`x`$"]
+        )
+
+    def test_formula_after_a_span_is_a_formula_again(self):
+        self.assertEqual(
+            formulae(r'<span style="color:red">y</span> $`x`$'), ["x"]
+        )
+
+    def test_formula_after_an_abbr_is_a_formula_again(self):
+        self.assertEqual(formulae(r'<abbr title="Full">A</abbr> $`x`$'), ["x"])
+
+
+class AlreadySubstitutedTests(InlineMathTestCase):
+    """Titles are resolveSymbols()ed before parseText sees them.
+
+    createSectionSlide, the presentation title and the presentation subtitle all
+    resolve symbols first, so a "\\`" or an entity reference inside a formula
+    arrives as one of the sentinel noncharacters.  Converting that buries an
+    unreadable character in the OMML, so the formula is left alone.
+    """
+
+    def test_substituted_escape_is_left_as_source(self):
+        text = resolveSymbols(r"$`a\`b`$")
+        self.assertEqual(formulae(text), [])
+        self.assertEqual(
+            paragraph.parseText(text), [["N", "$"], ["C", "a`b"], ["N", "$"]]
+        )
+
+    def test_substituted_entity_reference_is_left_as_source(self):
+        self.assertEqual(formulae(resolveSymbols(r"$`x &lt; y`$")), [])
+
+
+class StylesheetAvailabilityTests(InlineMathTestCase):
+    def test_install_directory_copy_is_enough(self):
+        """No mathxsl option, but a copy beside pptx_math.py - as with a block."""
+        globals.processingOptions.setOptionValues("mathxsl", "")
+        paragraph._mathInserterCache.clear()
+
+        with mock.patch.object(
+            pptx_math,
+            "_resolve_mathxsl_path",
+            return_value=self.stylesheet,
+        ):
+            self.assertEqual(formulae(r"$`x`$"), ["x"])
+
+    def test_without_a_stylesheet_the_line_is_left_as_it_was(self):
+        """Nothing is lifted, so the line tokenises exactly as it did before."""
+        globals.processingOptions.setOptionValues("mathxsl", "")
+        paragraph._mathInserterCache.clear()
+
+        with mock.patch.object(
+            pptx_math,
+            "_resolve_mathxsl_path",
+            side_effect=FileNotFoundError("no stylesheet"),
+        ):
+            with contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(
+                    paragraph.parseText(r"$`x`$"),
+                    [["N", "$"], ["C", "x"], ["N", "$"]],
+                )
+
+    def test_a_line_without_a_formula_never_asks_for_a_stylesheet(self):
+        paragraph._mathInserterCache.clear()
+
+        with mock.patch.object(
+            pptx_math, "_resolve_mathxsl_path"
+        ) as resolve:
+            paragraph.parseText("plain text with no maths in it")
+
+        resolve.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #241.

Follows up on #225, where we left inline maths for a later PR. I have built it and would like you to look it over — I am not assuming it should go in.

The syntax is GitHub's second inline form, ``$`LaTeX`$``, not a bare `$`. You were right on #225 that a bare `$` complicates parsing against other uses of the character; requiring a backtick against the dollar keeps `costs $5 to $10` out of it.

**Why it needs more than a regex.** `parseText` rewrites a line before it tokenises it, and the tokeniser then walks it a character at a time. Neither step can be handed LaTeX. On main today:

| written | what reaches the fragment |
|---|---|
| ``$`a*b`$`` | `ab` |
| ``$`x**2`$`` | `C:'x'`, `N:'2'`, `C:'$'` — the `**` closed the code span |
| ``$`\left[\frac{a}{b}\right]`$`` | `\left\frac{a}{b}\right]` |
| ``$`f\_g`$`` | `f_g` |

The `*` and `[` cases are the tokeniser rather than the replacements: those branches have no `else` that appends the character, so anything matching none of their cases disappears, inside a code span too.

So a formula is lifted out of the line before any of that runs, and one sentinel character (U+FDE4, in the range already used for the other constructs) is left in its place. The LaTeX never meets the replacements or the tokeniser; only its position does, which is what keeps a formula correctly placed among the bold, italic and link fragments.

**Where a formula is left as source text instead.** `paragraph.py` lists the tokeniser states in which a formula is safe rather than the ones it is not, so a state added later degrades to visible text instead of corrupting a fragment. That covers link text and URLs, a span's class or style and an abbr's title (all of which split their accumulated fragment when they close), and text that reached `parseText` already `resolveSymbols()`ed, as the section title, presentation title and subtitle routes do.

**Availability.** `getMathInserter()` goes through `_resolve_mathxsl_path`, so inline maths arrives on the same terms as a fenced `math` block. Without a stylesheet nothing is lifted and a line tokenises exactly as it does now; a line with no formula never asks for the stylesheet. I am reaching into `_resolve_mathxsl_path` from `paragraph.py` — glad to add a public name if you prefer.

**Known limits.** A table row is split on `|` before the text is parsed, so a formula in a cell has to spell bars as `\vert` or `\mid`. `latex2mathml` does not accept the optional argument on `\\`, so `\\[2pt]` renders `[2pt]` as text. The formula does not inherit bold from the run around it. The table of contents and funnel labels set their text directly rather than through `addFormattedText`, so inline maths does not apply there.

**Contents.** `paragraph.py` +152; `pptx_math.py` untouched, as `make_inline_omml` and `inject_inline_math` are already there. `test/test_inline_math.py`, 28 tests in the style of `test_pptx_math.py` — I broke each load-bearing branch in turn and checked a test fails for it. `test/mathTest.md`, a sample like the other fixtures; the screenshot below is that file built with the template in the repo.

Docs untouched. `docs/latex.mdp` would need a short inline section — say the word and I will draft one.

![image](https://github.com/user-attachments/assets/e1494436-96ed-4226-97b9-c6284b344773)
![image](https://github.com/user-attachments/assets/b4760bd5-31fe-444b-9b53-15561e1f00e3)