### PR TITLE
Add a textLanguage option to set the language on every text run

### DIFF
--- a/md2pptx
+++ b/md2pptx
@@ -44,6 +44,7 @@ import platform
 import shutil
 import socket
 from pptx.oxml import parse_xml
+from pptx.oxml.ns import qn
 import uuid
 import funnel
 import runPython
@@ -394,6 +395,41 @@ def createExpandingSections(prs):
 
         # Insert the fragment in the extension list in presentation.xml
         extLst.insert(0, xmlFragment)
+
+
+def setTextLanguage(prs, language):
+    """Set the language attribute on every text run in the presentation.
+
+    PowerPoint picks its line breaking and proofing rules from this
+    attribute. The runs md2pptx creates have no <a:rPr> element at all, so
+    there is nothing for PowerPoint to go on and it falls back to whatever
+    the editing language happens to be. For Japanese and Chinese that means
+    the line breaking rules are not applied and punctuation can be pushed
+    to the start of a line.
+
+    Returns the number of runs changed. Runs that already carry a language -
+    for example ones that came in from the template - are left alone.
+    """
+    changed = 0
+
+    for slide in prs.slides:
+        for run in slide.shapes._spTree.iter(qn("a:r")):
+            runProperties = run.find(qn("a:rPr"))
+
+            if runProperties is None:
+                # <a:rPr> has to come before <a:t> so insert it rather than
+                # appending it
+                runProperties = run.makeelement(qn("a:rPr"), {})
+                run.insert(0, runProperties)
+
+            elif runProperties.get("lang") is not None:
+                # Leave a run that already has a language alone
+                continue
+
+            runProperties.set("lang", language)
+            changed += 1
+
+    return changed
 
 
 def deleteSlide(prs, slideNumber):
@@ -5149,6 +5185,8 @@ globals.processingOptions.setOptionValuesArray(
 
 globals.processingOptions.setOptionValues("monoFont", "Courier")
 
+globals.processingOptions.setOptionValues("textLanguage", "")
+
 globals.processingOptions.setOptionValues("mathxsl", "")
 
 topHeadingLevel = 1
@@ -5429,6 +5467,14 @@ for line in metadata_lines:
 
     elif name == "monofont":
         globals.processingOptions.setOptionValues(name, value)
+
+    elif name == "textlanguage":
+        if re.match(r"^[A-Za-z]{2,3}(-[A-Za-z0-9]+)*$", value):
+            globals.processingOptions.setOptionValues(name, value)
+        else:
+            print(
+                f"TextLanguage value '{value}' unsupported. A language tag such as \"ja-JP\" required."
+            )
 
     elif name == "marginbase":
         globals.processingOptions.setOptionValues(name, Inches(float(value)))
@@ -7182,6 +7228,11 @@ if globals.processingOptions.getCurrentOption("SectionsExpand"):
 onPresentationBeforeSave = globals.processingOptions.getCurrentOption("onPresentationBeforeSave")
 if onPresentationBeforeSave != "":
     exec(open(onPresentationBeforeSave).read())
+
+# Maybe set the language on every run - for line breaking and proofing
+textLanguage = globals.processingOptions.getCurrentOption("textLanguage")
+if textLanguage != "":
+    setTextLanguage(prs, textLanguage)
 
 prs.save(output_filename)
 


### PR DESCRIPTION
## Add a `textLanguage` option so PowerPoint knows what language the text is

### The problem

The runs md2pptx creates have no `<a:rPr>` element at all:

```xml
<a:r><a:t>...</a:t></a:r>
```

Every run PowerPoint itself writes carries a language:

```xml
<a:r><a:rPr lang="ja-JP"/><a:t>...</a:t></a:r>
```

PowerPoint takes its line breaking and proofing rules from that attribute. With
nothing there it falls back to the editing language, and for Japanese and
Chinese that is visible on the slide: the line breaking rules (kinsoku shori)
are not applied, so a comma or a full stop can be pushed to the start of the
next line - sometimes onto a line of its own - where the rules would have kept
it at the end of the previous line.

It is not only a CJK problem, since the proofing language of the whole deck is
unset today, but CJK is where it shows up in the rendered output.

It is easy to mistake for a text-length problem: shortening the sentence never
fixes it, because the rule is never being applied in the first place. It became
clear only after diffing a generated deck against the same deck opened and
saved by PowerPoint, where the only difference in the XML was `lang`.

### The change

A new presentation-level metadata option:

```
textLanguage: ja-JP
```

It takes a language tag and writes it on every run in the presentation, just
before the file is saved - after the `onPresentationBeforeSave` exit, so runs
that an exit created are covered too.

- Runs that already carry a language (for example ones that came in from the
  template) are left alone.
- The default is empty, i.e. today's behaviour, so no existing deck changes.
- A value that is not a language tag is reported and ignored, in the same style
  as `TOCStyle`.

Doing it in one pass before saving rather than at each `add_run` keeps the
change to ~50 lines in one file; happy to push it down into run creation
instead if you would prefer that.

### How it was checked

- `textLanguage: ja-JP` - every run in the output gets `lang="ja-JP"`, and the
  line breaking changes: with a paragraph of Japanese long enough to wrap, the
  punctuation that used to start a line is pulled back to the end of the
  previous one.
- No option set - the output is **byte-identical** to the same deck built with
  v7.0 (compared entry by entry inside the .pptx).
- A bad value (`textLanguage: not a tag`) prints the message and builds as if
  the option were absent.
- `test/fullPresentation.md`, `test/cardTest.md` and `test/codetest.md` still
  build.

One thing worth knowing: setting the language also lets PowerPoint choose
between the theme's latin and East Asian fonts for ambiguous characters, so
text can render slightly differently. That is the same thing a PowerPoint-saved
file does, and it made a generated deck match the PowerPoint-saved version
exactly.

I have not touched `docs/user-guide.mdp` - say the word and I will add the
option to the user guide in whatever wording you prefer.
